### PR TITLE
Add start-app example which follow Elm architecute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# elm-storage
+
+> Local Storage in Elm
+
+## Example
+
+```bash
+cd example
+elm-reactor
+```
+

--- a/elm-package.json
+++ b/elm-package.json
@@ -7,7 +7,6 @@
         "src"
     ],
     "exposed-modules": [
-        "Storage"
     ],
     "native-modules": true,
     "dependencies": {

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,2 @@
+elm-stuff
+elm.js

--- a/example/App.elm
+++ b/example/App.elm
@@ -1,0 +1,84 @@
+module App where
+
+import Effects exposing (Effects)
+import Json.Encode as JE exposing (string, Value)
+import Json.Decode as JD
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (on, targetValue)
+import Storage exposing (..)
+import Task exposing (..)
+
+import Debug
+
+type alias Model = String
+
+initialModel : Model
+initialModel =
+  ""
+
+init : (Model, Effects Action)
+init =
+  ( initialModel
+  , getInputFromStorage
+  )
+
+-- UPDATE
+
+type Action
+  = GetStorage (Result String ())
+  | SetStorage String
+  | UpdateModel (Result String String)
+
+
+update : Action -> Model -> (Model, Effects Action)
+update action model =
+  case action of
+    GetStorage result ->
+      case result of
+        Ok s ->
+          (model, getInputFromStorage)
+        Err err ->
+          (model, Effects.none)
+
+
+    SetStorage s ->
+      -- Don't update the model here, instead after this action is done, the
+      -- effect should call another action to update the model.
+      (model, sendInputToStorage s)
+
+    UpdateModel result ->
+      case result of
+        Ok s ->
+          (s, Effects.none)
+        Err err ->
+          (model, Effects.none)
+
+
+sendInputToStorage : String -> Effects Action
+sendInputToStorage s =
+  Storage.setItem "Test" (JE.string s)
+    |> Task.toResult
+    |> Task.map GetStorage
+    |> Effects.task
+
+getInputFromStorage : Effects Action
+getInputFromStorage =
+  getItem "Test" JD.string
+    |> Task.toResult
+    |> Task.map UpdateModel
+    |> Effects.task
+
+-- VIEW
+
+view : Signal.Address Action -> Model -> Html
+view address model =
+  div []
+  [ h2 [] [ text "Storage example"]
+  , input
+      [ on "input" targetValue (Signal.message address << SetStorage)
+      , required True
+      , placeholder "Add some text"
+      ] []
+  , text model
+  ]

--- a/example/App.elm
+++ b/example/App.elm
@@ -11,11 +11,11 @@ import Task exposing (..)
 
 import Debug
 
-type alias Model = String
+type alias Model = Maybe String
 
 initialModel : Model
 initialModel =
-  ""
+  Nothing
 
 init : (Model, Effects Action)
 init =
@@ -50,7 +50,7 @@ update action model =
     UpdateModel result ->
       case result of
         Ok s ->
-          (s, Effects.none)
+          (Just s, Effects.none)
         Err err ->
           (model, Effects.none)
 
@@ -73,6 +73,14 @@ getInputFromStorage =
 
 view : Signal.Address Action -> Model -> Html
 view address model =
+  let
+    existingValue =
+      case model of
+        Just s ->
+          text s
+        Nothing ->
+          text ""
+  in
   div []
   [ h2 [] [ text "Storage example"]
   , input
@@ -80,5 +88,5 @@ view address model =
       , required True
       , placeholder "Add some text"
       ] []
-  , text model
+  , existingValue
   ]

--- a/example/Main.elm
+++ b/example/Main.elm
@@ -1,0 +1,24 @@
+module Main where
+
+import Effects exposing (Never)
+import App exposing (init, update, view)
+import StartApp
+import Task
+
+
+app =
+  StartApp.start
+    { init = init
+    , update = update
+    , view = view
+    , inputs = []
+    }
+
+
+main =
+  app.html
+
+
+port tasks : Signal (Task.Task Never ())
+port tasks =
+  app.tasks

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/USER/PROJECT.git",
+    "license": "BSD3",
+    "source-directories": [
+        "../src",
+        "."
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "dependencies": {
+        "elm-lang/core": "2.1.0 <= v < 3.0.0",
+        "evancz/elm-effects": "2.0.0 <= v < 3.0.0",
+        "evancz/elm-html": "4.0.1 <= v < 5.0.0",
+        "evancz/start-app": "2.0.1 <= v < 3.0.0"
+    },
+    "elm-version": "0.15.1 <= v < 0.16.0"
+}


### PR DESCRIPTION
![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/125707/10269590/1490888c-6ae5-11e5-927f-b914b7a6ef1f.gif)

This example makes the use of the package clearer in the elm architecture context.

Note that in order for elm-reactor to work, one has to cd into the `example` directory. Otherwise the `import Storage` doesn't work - I wonder if there's  a nicer solution?
